### PR TITLE
Fixed typo

### DIFF
--- a/website/pages/en/index.js
+++ b/website/pages/en/index.js
@@ -158,7 +158,7 @@ class Index extends React.Component {
             title: 'Universal Rendering',
           },
           {
-            content: 'You can render Nova views on any web technology and framework such as Nuxt, GatsbyJS, Wordpress, Flask and more.',
+            content: 'You can render Nova views on any web technology and framework such as Nuxt, GatsbyJS, WordPress, Flask and more.',
             image: `${baseUrl}img/undraw_wordpress.svg`,
             imageAlign: 'top',
             title: 'Consumer Agnostic',

--- a/website/pages/en/index.js
+++ b/website/pages/en/index.js
@@ -158,7 +158,7 @@ class Index extends React.Component {
             title: 'Universal Rendering',
           },
           {
-            content: 'You can render Nova views on any web technology and framework such as Nuxt, GatsbyJS, Worpdpress, Flask and more.',
+            content: 'You can render Nova views on any web technology and framework such as Nuxt, GatsbyJS, Wordpress, Flask and more.',
             image: `${baseUrl}img/undraw_wordpress.svg`,
             imageAlign: 'top',
             title: 'Consumer Agnostic',


### PR DESCRIPTION
Under features there was "Worpdpress", it should be "Wordpress", so this change fixes this.