### PR TITLE
feat(website): add DocSearch as recommended by docusaurus

### DIFF
--- a/website/siteConfig.js
+++ b/website/siteConfig.js
@@ -22,6 +22,10 @@ const users = [
 
 const baseUrl = '/website/';
 const siteConfig = {
+  algolia: {
+    apiKey: '5bc14a3c57907625dcf0191f5ba91bfc',
+    indexName: 'ara-framework',
+  },
   title: 'Ara Framework', // Title for your website.
   tagline: 'Build Micro-frontends easily using Airbnb Hypernova',
   url: '"https://ara-framework.github.io', // Your website URL


### PR DESCRIPTION
👋 team,

I am working on DocSearch. [We have an integration for Docusaurus](https://docusaurus.io/docs/en/search#enabling-the-search-bar). We thought it is a shame you can not also used this search that you can [find on reactjs for example](https://reactjs.org/).

This PR will add DocSearch to the documentation website. It will allow an user to have a learn-as-you-type experience by displaying results thanks to a dropdown in a live way.

Let me know if you need anything.